### PR TITLE
iOS file location update

### DIFF
--- a/include/w/base/ResourceManagerPrivate.hpp
+++ b/include/w/base/ResourceManagerPrivate.hpp
@@ -55,6 +55,9 @@ namespace w
         #ifdef ANDROID
             static AAssetManager* androidAssetManager();
             static void setAndroidAssetManager(AAssetManager* androidAssetManager);
+        #elif __APPLE__
+            static std::string appDirectory;
+            static const std::string& getAppDirectory();
         #endif
         static bool textureExists(const std::string& filename);
         static bool bundledFileExists(const std::string& filename);


### PR DESCRIPTION
Updated iOS file location to use Library\Application Support instead of Documents.